### PR TITLE
Bugfix when calling PNGImage.readImage - scope was missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 CHANGELOG
 =========
 
-v1.1.0 - 04/21/15
+v1.0.11 - 05/26/15
+* Bugfix when calling PNGImage.readImage - scope was missing
+
+v1.0.10 - 04/21/15
 * Update PNGjs-Image (with additional synchronous behavior)
 * Add runSync for synchronous comparison
 

--- a/index.js
+++ b/index.js
@@ -698,10 +698,10 @@ BlinkDiff.prototype = {
 	_loadImage: function (path, image) {
 
 		if (image instanceof Buffer) {
-			return Promise.denodeify(PNGImage.loadImage)(image);
+			return Promise.denodeify(PNGImage.loadImage).call(PNGImage, image);
 
 		} else if ((typeof path === 'string') && !image) {
-			return Promise.denodeify(PNGImage.readImage)(path);
+			return Promise.denodeify(PNGImage.readImage).call(PNGImage, path);
 
 		} else {
 			return image;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blink-diff",
-	"version": "1.0.10",
+	"version": "1.0.11",
 	"description": "A lightweight image comparison tool",
 	"license": "MIT",
 	"main": "index.js",


### PR DESCRIPTION
Bugfix for bug that was reported on the PNGjs-Image repo:
yahoo/pngjs-image#9